### PR TITLE
Yearly copyright update - 2022

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/PBSPro.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/PBSPro.pm
@@ -11,7 +11,7 @@ Bio::EnsEMBL::Hive::Meadow::PBSPro
 =head1 LICENSE
 
     Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-    Copyright [2016-2017] EMBL-European Bioinformatics Institute
+    Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
     You may obtain a copy of the License at


### PR DESCRIPTION
Yearly copyright update to 2022.

Note: As the copyright in this script hasn't been updated since 2017, I'm not sure if it should be updated now. However, since version/2.6 has been updated in 2021 and since this repo is mentioned in the Yearly License Update Confluence page, I'm submitting this PR.